### PR TITLE
[RVV] Moved weight repacking for FC to the gemm 

### DIFF
--- a/source/thead_rvv/fp32/fullyconnected.c
+++ b/source/thead_rvv/fp32/fullyconnected.c
@@ -22,16 +22,7 @@ int shl_rvv_fullyconnected_init_fp32(struct csinn_tensor *input, struct csinn_te
                                      struct csinn_tensor *weights, struct csinn_tensor *bias,
                                      struct csinn_fc_params *params)
 {
-    const int weights_dims_count = weights->dim_count;
-    const int out_nodes = weights->dim[weights_dims_count - 2];
-    const int in_nodes = weights->dim[weights_dims_count - 1];
     struct csinn_callback *cb = params->base.cb;
-
-    struct csinn_session *sess = params->base.sess;
-    bool binary_model_op_init = shl_rvv_get_binary_model_op_init(sess);
-    if (!binary_model_op_init) {
-        shl_rvv_fc_gemm_reorder_weight_fp32(weights);
-    }
     cb->exec = shl_rvv_fullyconnected_gemm_fp32;
 
     return CSINN_TRUE;

--- a/source/thead_rvv/fp32/fullyconnected_fp32.c
+++ b/source/thead_rvv/fp32/fullyconnected_fp32.c
@@ -93,9 +93,12 @@ int shl_rvv_fullyconnected_gemm_fp32(struct csinn_tensor *input, struct csinn_te
     int k = accum_depth;
 
     float *input_reorder = (float *)shl_mem_alloc(m * k * sizeof(float));
+    float *weights_reorder = (float *)shl_mem_alloc(n * k * sizeof(float));
+    reorder_weight_npack2n_fp32(weights_data, weights_reorder, n, k);
     shl_rvv_reorder_a_block_12xk_fp32(input_data, input_reorder, m, k, m, k);
-    shl_rvv_gemm_a0b1_12xpack2n_fp32(output_data, input_reorder, weights_data, bias_data, m, k, n);
+    shl_rvv_gemm_a0b1_12xpack2n_fp32(output_data, input_reorder, weights_reorder, bias_data, m, k, n);
 
     shl_mem_free(input_reorder);
+    shl_mem_free(weights_reorder);
     return CSINN_TRUE;
 }


### PR DESCRIPTION
The current implementation of FC makes weights reordering on initialization stage and rewrites data by the weights data pointer. However, in general case implementations cannot change input data.
The PR moves reordering logic to the kernel call.

Prerequisite: https://github.com/openvinotoolkit/shl/pull/2